### PR TITLE
[feat/#3] : 서비스 관련 엔티티 정의

### DIFF
--- a/src/main/java/com/example/nangbomi/food/Food.java
+++ b/src/main/java/com/example/nangbomi/food/Food.java
@@ -38,7 +38,7 @@ public class Food {
     @Column(name = "comment")
     private String comment;
 
-    @Convert()
+    @Convert(converter = FoodPositionConverter.class)
     @Column(name = "food_position", nullable = false)
     private FoodPosition foodPosition;
 

--- a/src/main/java/com/example/nangbomi/food/Food.java
+++ b/src/main/java/com/example/nangbomi/food/Food.java
@@ -1,0 +1,50 @@
+package com.example.nangbomi.food;
+
+import com.example.nangbomi.food_type.FoodType;
+import com.example.nangbomi.refri.Refri;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "food")
+public class Food {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "type_id", nullable = false)
+    private FoodType type;
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "register_date", nullable = false)
+    private Instant registerDate;
+
+    @Column(name = "expiration_date", nullable = false)
+    private Instant expirationDate;
+
+    @ColumnDefault("1")
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Lob
+    @Column(name = "comment")
+    private String comment;
+
+    @ColumnDefault("'Refrigerator'")
+    @Lob
+    @Column(name = "food_position", nullable = false)
+    private String foodPosition;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "refri_id", nullable = false)
+    private Refri refri;
+
+}

--- a/src/main/java/com/example/nangbomi/food/Food.java
+++ b/src/main/java/com/example/nangbomi/food/Food.java
@@ -38,10 +38,9 @@ public class Food {
     @Column(name = "comment")
     private String comment;
 
-    @ColumnDefault("'Refrigerator'")
-    @Lob
+    @Convert()
     @Column(name = "food_position", nullable = false)
-    private String foodPosition;
+    private FoodPosition foodPosition;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "refri_id", nullable = false)

--- a/src/main/java/com/example/nangbomi/food/FoodPosition.java
+++ b/src/main/java/com/example/nangbomi/food/FoodPosition.java
@@ -1,0 +1,26 @@
+package com.example.nangbomi.food;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum FoodPosition {
+    FREEZER(0),
+    REFRIGERATOR(1),
+    ROOM(2);
+
+    private final int code;
+
+    public static FoodPosition valueOf(int code) {
+        return Arrays.stream(FoodPosition.values())
+                .filter(value -> value.getCode() == code)
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("유효하지 않은 FoodPosition: " + code)
+                );
+    }
+}

--- a/src/main/java/com/example/nangbomi/food/FoodPositionConverter.java
+++ b/src/main/java/com/example/nangbomi/food/FoodPositionConverter.java
@@ -1,0 +1,17 @@
+package com.example.nangbomi.food;
+
+import jakarta.persistence.AttributeConverter;
+
+public class FoodPositionConverter implements AttributeConverter<FoodPosition, Integer> {
+
+
+    @Override
+    public Integer convertToDatabaseColumn(FoodPosition foodPosition) {
+        return foodPosition.getCode();
+    }
+
+    @Override
+    public FoodPosition convertToEntityAttribute(Integer dbData) {
+        return FoodPosition.valueOf(dbData);
+    }
+}

--- a/src/main/java/com/example/nangbomi/food_type/FoodType.java
+++ b/src/main/java/com/example/nangbomi/food_type/FoodType.java
@@ -1,0 +1,36 @@
+package com.example.nangbomi.food_type;
+
+import com.example.nangbomi.food.Food;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "food_type")
+public class FoodType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "type_id", nullable = false)
+    private Long id;
+
+    @Column(name = "type_name", nullable = false, length = 20)
+    private String typeName;
+
+    @Column(name = "type_code", nullable = false, length = 20)
+    private String typeCode;
+
+    @Column(name = "expiration_period")
+    private LocalDate expirationPeriod;
+
+    @Column(name = "information", length = 100)
+    private String information;
+
+    @OneToMany(mappedBy = "type", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Food> foods;
+
+}

--- a/src/main/java/com/example/nangbomi/refri/Refri.java
+++ b/src/main/java/com/example/nangbomi/refri/Refri.java
@@ -1,0 +1,37 @@
+package com.example.nangbomi.refri;
+
+import com.example.nangbomi.food.Food;
+import com.example.nangbomi.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "refri")
+public class Refri {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "refri_name", nullable = false, length = 20)
+    private String refriName;
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "refri_created_time", nullable = false)
+    private Instant refriCreatedTime;
+
+    @OneToMany(mappedBy = "refri", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Food> foods;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/example/nangbomi/user/User.java
+++ b/src/main/java/com/example/nangbomi/user/User.java
@@ -1,0 +1,41 @@
+package com.example.nangbomi.user;
+
+import com.example.nangbomi.refri.Refri;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 10)
+    private String name;
+
+    @Column(name = "nickname", nullable = false, length = 100)
+    private String nickname;
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_time", nullable = false)
+    private Instant createdTime;
+
+    @ColumnDefault("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @Column(name = "updated_time")
+    private Instant updatedTime;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Refri> refries;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,14 +4,15 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/refri?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/refri?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul
     username: root
     password: 0000
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: create
+    #hibernate:
+
+      #ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
# ✒️ 관련 이슈번호

- feat/#3 
   
   

# 🔑 Key Changes   
1. User : 회원 관련 정보를 저장하는 엔티티
2. Refri : 냉장고 관련 정보를 저장하는 엔티티
3. Fod : 음식의 위치, 유통기한, 메모사항 등을 저장하는 엔티티
4. FoodType : 유통기한이 표시되지 않은 음식의 유통기한을 통상적인 식품 정보로부터 불러오기 위해 식품 타입별 보관 방법, 기타 메모 등을 저장하기 위한 엔티티
   
   

# 📢 To Reviewers
> food_position 값을 변경 

enum("freezer", "refrigerator", "room") ➔ 상태값을 나타내는 int (0,1, 2)로 표현